### PR TITLE
Update des requêtes "daily" dans influxdb.py

### DIFF
--- a/app/influxdb.py
+++ b/app/influxdb.py
@@ -30,7 +30,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
     }
 
     f.log(f" => Import daily")
-    query = f"SELECT * FROM consumption_daily WHERE pdl = '{pdl}';"
+    query = f"SELECT * FROM consumption_daily WHERE (pdl = '{pdl}' AND date < date('now'));"
     cur.execute(query)
     query_result = cur.fetchall()
     for result in query_result:


### PR DESCRIPTION
Le jour courant devrait être exclu dans les requêtes "daily" puisque qu'Enedis fournit les données à j-1 et que cela créer un enregistrement pour "Today" avec des valeurs à zero dans influxdb.