### PR TITLE
Update datetime storage in influxdb

### DIFF
--- a/app/influxdb.py
+++ b/app/influxdb.py
@@ -39,7 +39,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
         value_kwh = value_wh / 1000
         current_price = forceRound(value_kwh * price["BASE"], 4)
         f.log(f"Insert daily {date} => {value_wh}", "DEBUG")
-        dateObject = datetime.strptime(date, '%Y-%m-%d')
+        dateObject = datetime.strptime(date, '%Y-%m-%d').astimezone(pytz.UTC)
         p = influxdb_client.Point("enedisgateway_daily") \
             .tag("pdl", pdl) \
             .tag("year", dateObject.strftime("%Y")) \
@@ -64,7 +64,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
         value_kwh = value_wh / 1000
         current_price = forceRound(value_kwh * price[measure_type], 4)
         f.log(f"Insert detail {date} => {value}", "DEBUG")
-        dateObject = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        dateObject = datetime.strptime(date, '%Y-%m-%d %H:%M:%S').astimezone(pytz.UTC)
         p = influxdb_client.Point("enedisgateway_detail") \
             .tag("pdl", pdl) \
             .tag("measure_type", measure_type) \


### PR DESCRIPTION
Comme indiqué ici ... https://influxdb-client.readthedocs.io/en/latest/api.html#influxdb_client.client.write.point.Point.time
la valeur .time est supposé être en UTC si aucun TZ n'est spécifié, or la valeur dateObject des tables est déja en TZ Europe/Paris mais cela n'est pas spécifié dans le formatage.
C'est donc la valeur Europe/Paris qui est inséré dans influxdb qui la consière en UTC.
Il me semble que cela pourrait être corrigé avec ce PR.