### PR TITLE
Update Influxdb.py

### DIFF
--- a/app/influxdb.py
+++ b/app/influxdb.py
@@ -5,6 +5,8 @@ from pprint import pprint
 import locale
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
+from influxdb_client.domain.write_precision import WritePrecision
+from pytz import timezone
 import pytz
 
 from importlib import import_module
@@ -12,7 +14,8 @@ main = import_module("main")
 f = import_module("function")
 
 locale.setlocale(locale.LC_ALL, 'fr_FR.UTF-8')
-timezone = pytz.timezone('Europe/Paris')
+CET = timezone('Europe/Paris')
+UTC = pytz.utc
 
 def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
 
@@ -30,7 +33,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
     }
 
     f.log(f" => Import daily")
-    query = f"SELECT * FROM consumption_daily WHERE pdl = '{pdl}';"
+    query = f"SELECT * FROM consumption_daily WHERE (pdl = '{pdl}' AND date < date('now'));"
     cur.execute(query)
     query_result = cur.fetchall()
     for result in query_result:
@@ -39,7 +42,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
         value_kwh = value_wh / 1000
         current_price = forceRound(value_kwh * price["BASE"], 4)
         f.log(f"Insert daily {date} => {value_wh}", "DEBUG")
-        dateObject = datetime.strptime(date, '%Y-%m-%d')
+        dateObject = CET.localize(datetime.strptime(date, '%Y-%m-%d'))
         p = influxdb_client.Point("enedisgateway_daily") \
             .tag("pdl", pdl) \
             .tag("year", dateObject.strftime("%Y")) \
@@ -64,7 +67,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
         value_kwh = value_wh / 1000
         current_price = forceRound(value_kwh * price[measure_type], 4)
         f.log(f"Insert detail {date} => {value}", "DEBUG")
-        dateObject = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        dateObject = CET.localize(datetime.strptime(date, '%Y-%m-%d %H:%M:%S'))
         p = influxdb_client.Point("enedisgateway_detail") \
             .tag("pdl", pdl) \
             .tag("measure_type", measure_type) \

--- a/app/influxdb.py
+++ b/app/influxdb.py
@@ -42,7 +42,7 @@ def influxdb_insert(cur, con, pdl, pdl_config, influxdb, influxdb_api):
         value_kwh = value_wh / 1000
         current_price = forceRound(value_kwh * price["BASE"], 4)
         f.log(f"Insert daily {date} => {value_wh}", "DEBUG")
-        dateObject = CET.localize(datetime.strptime(date, '%Y-%m-%d'))
+        dateObject = UTC.localize(datetime.strptime(date, '%Y-%m-%d'))
         p = influxdb_client.Point("enedisgateway_daily") \
             .tag("pdl", pdl) \
             .tag("year", dateObject.strftime("%Y")) \


### PR DESCRIPTION
Première modif:
Le jour courant devrait être exclu dans les requêtes "daily" puisque qu'Enedis fournit les données à j-1 et que cela créer un enregistrement pour "Today" avec des valeurs à zero dans influxdb.
Deuxiéme modif:
Comme indiqué ici ... https://influxdb-client.readthedocs.io/en/latest/api.html#influxdb_client.client.write.point.Point.time
la valeur .time est supposée être en UTC si aucun TZ n'est spécifié, or la valeur dateObject des tables est déja en TZ Europe/Paris mais cela n'est pas spécifié dans le formatage.
C'est donc la valeur Europe/Paris qui est inséré dans influxdb qui la consière donc à tort en UTC.
Solution proposée: conversion des valeurs .time en CET pour cohérence des informations dans Influx/Grafana.